### PR TITLE
Feature: Favoriting Pets

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -11,6 +11,7 @@ class FavoritesController < ApplicationController
   def index
     @pets = Pet.all
     @pets = @pets.find_all { |pet| favorites.pets.has_key?(pet.id.to_s) }
+    flash[:notice] = "You have no favorited pets" if @pets.empty?
   end
 
   def destroy

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -8,4 +8,8 @@ class FavoritesController < ApplicationController
     flash[:notice] = "You have added #{pet.name} to your favorites."
     redirect_to "/pets/#{params[:pet_id]}"
   end
+
+  def index
+    @pets = Pet.all
+  end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -20,4 +20,9 @@ class FavoritesController < ApplicationController
     flash[:notice] = "#{pet.name} has been removed from your favorites."
     redirect_back(fallback_location: "/favorites")
   end
+
+  def delete_all
+    session.clear
+    redirect_back(fallback_location: "/favorites")
+  end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,11 @@
+class FavoritesController < ApplicationController
+
+  def update
+    pet = Pet.find(params[:pet_id])
+    @favorites = Favorites.new(session[:favorites])
+    @favorites.add_pet(pet.id)
+    session[:favorites] = @favorites.pets
+    flash[:notice] = "You have added #{pet.name} to your favorites."
+    redirect_to "/pets/#{params[:pet_id]}"
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,7 +2,7 @@ class FavoritesController < ApplicationController
 
   def update
     pet = Pet.find(params[:pet_id])
-    favorites.add_pet(pet.id)
+    favorites.add_pet(params[:pet_id])
     session[:favorites] = favorites.pets
     flash[:notice] = "You have added #{pet.name} to your favorites."
     redirect_to "/pets/#{params[:pet_id]}"
@@ -10,5 +10,12 @@ class FavoritesController < ApplicationController
 
   def index
     @pets = Pet.all
+  end
+
+  def destroy
+    pet = Pet.find(params[:pet_id])
+    favorites.remove_pet(params[:pet_id])
+    flash[:notice] = "#{pet.name} has been removed from your favorites."
+    redirect_to "/pets/#{params[:pet_id]}"
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -10,12 +10,13 @@ class FavoritesController < ApplicationController
 
   def index
     @pets = Pet.all
+    @pets = @pets.find_all { |pet| favorites.pets.has_key?(pet.id.to_s) }
   end
 
   def destroy
     pet = Pet.find(params[:pet_id])
     favorites.remove_pet(params[:pet_id])
     flash[:notice] = "#{pet.name} has been removed from your favorites."
-    redirect_to "/pets/#{params[:pet_id]}"
+    redirect_back(fallback_location: "/favorites")
   end
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -5,6 +5,7 @@ class PetsController < ApplicationController
 
   def show
     pet
+    @favorites = Favorites.new(session[:favorites])
   end
 
   def new

--- a/app/models/favorites.rb
+++ b/app/models/favorites.rb
@@ -11,6 +11,7 @@ class Favorites
 
   def add_pet(id)
     pet_id = id.to_s
+    @pets[pet_id] ||= 0
     @pets[pet_id] += 1
   end
 end

--- a/app/models/favorites.rb
+++ b/app/models/favorites.rb
@@ -1,0 +1,16 @@
+class Favorites
+  attr_reader :pets
+
+  def initialize(initial_pets)
+    @pets = initial_pets || Hash.new(0)
+  end
+
+  def total_count
+    @pets.values.sum
+  end
+
+  def add_pet(id)
+    pet_id = id.to_s
+    @pets[pet_id] += 1
+  end
+end

--- a/app/models/favorites.rb
+++ b/app/models/favorites.rb
@@ -14,4 +14,9 @@ class Favorites
     @pets[pet_id] ||= 0
     @pets[pet_id] += 1
   end
+
+  def remove_pet(id)
+    @pets.delete_if { |pet_id, _| pet_id == id.to_s }
+  end
+
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -5,6 +5,7 @@
       <section>
         <%= image_tag(pet.image, alt: "#{pet.name}'s photo.", id: "#{pet.name.downcase}-image") %>
         <h2>Name: <%= link_to(pet.name, "/pets/#{pet.id}") %></h2>
+        <%= button_to("Remove Pet from Favorites", "/favorites/#{pet.id}", method: :delete)%>
       </section>
     <% end %>
   </main>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -8,5 +8,8 @@
         <%= button_to("Remove Pet from Favorites", "/favorites/#{pet.id}", method: :delete)%>
       </section>
     <% end %>
+    <footer>
+      <%= link_to("Remove All Pets from Favorites", "/favorites", method: :delete) %>
+    </footer>
   </main>
 </div>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,11 @@
+<html lang="en">
+<div class="container">
+  <main class="index">
+    <% @pets.each do |pet| %>
+      <section>
+        <%= image_tag(pet.image, alt: "#{pet.name}'s photo.", id: "#{pet.name.downcase}-image") %>
+        <h2>Name: <%= link_to(pet.name, "/pets/#{pet.id}") %></h2>
+      </section>
+    <% end %>
+  </main>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,10 +9,17 @@
   </head>
 
   <body>
+    <% flash.each do |type, message| %>
+    <p><%= message %></p>
+    <% end %>
+
     <nav class="navbar">
       <%= link_to("Home Page", "/") %>
       <%= link_to("Pet Index", "/pets") %>
       <%= link_to("Shelter Index", "/shelters") %>
+      <section id="favorites">
+        <p>Favorites: <%= @favorites.nil? ? 0 : @favorites.total_count %></p>
+      </section>
     </nav>
     <%= yield %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,9 +17,7 @@
       <%= link_to("Home Page", "/") %>
       <%= link_to("Pet Index", "/pets") %>
       <%= link_to("Shelter Index", "/shelters") %>
-      <section id="favorites">
-        <p>Favorites: <%= @favorites.nil? ? 0 : @favorites.total_count %></p>
-      </section>
+      <%= link_to("Favorites: #{@favorites.nil? ? 0 : @favorites.total_count}", "/favorites") %>
     </nav>
     <%= yield %>
   </body>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -6,12 +6,16 @@
                   id: "#{@pet.name.downcase.gsub(" ", "-")}-image") %>
 
     <h1>Name: <%= link_to(@pet.name, "/pets/#{@pet.id}") %></h1>
-    <%= button_to "Add Pet to Favorites", "/favorites/#{@pet.id}", method: :patch %>
     <%= tag.p "Description: #{@pet.description}" %>
     <%= tag.p "Age: #{@pet.approximate_age}" %>
     <%= tag.p "Sex: #{@pet.sex}" %>
     <%= tag.p "Status: #{@pet.status}" %>
     <%= link_to("Update Pet", "/pets/#{@pet.id}/edit") %>
     <%= link_to("Delete Pet", "/pets/#{@pet.id}/", method: :delete) %>
+    <% if favorites.pets.has_key?(@pet.id.to_s) %>
+    <%= button_to("Remove Pet from Favorites", "/favorites/#{@pet.id}", method: :delete)%>
+    <% else %>
+    <%= button_to("Add Pet to Favorites", "/favorites/#{@pet.id}", method: :patch) %>
+    <% end %>
   </main>
 </div>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -6,6 +6,7 @@
                   id: "#{@pet.name.downcase.gsub(" ", "-")}-image") %>
 
     <h1>Name: <%= link_to(@pet.name, "/pets/#{@pet.id}") %></h1>
+    <%= button_to "Add Pet to Favorites", "/favorites/#{@pet.id}", method: :patch %>
     <%= tag.p "Description: #{@pet.description}" %>
     <%= tag.p "Age: #{@pet.approximate_age}" %>
     <%= tag.p "Sex: #{@pet.sex}" %>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,10 +1,6 @@
 <html lang="en">
   <div class="container">
 
-    <% flash.each do |type, message| %>
-    <p><%= message %></p>
-    <% end %>
-
     <main>
       <%= form_tag "/shelters/#{@shelter_id}/reviews/#{@review_id}", method: :patch do %>
         <%= label_tag :title %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,10 +1,6 @@
 <html lang="en">
   <div class="container">
 
-    <% flash.each do |type, message| %>
-    <p><%= message %></p>
-    <% end %>
-
     <main>
       <%= form_tag "/shelters/#{@shelter_id}/reviews", method: :post do %>
         <%= label_tag :title %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,6 @@ Rails.application.routes.draw do
   get "/shelters/:id/reviews/:review_id/edit", to: "reviews#edit"
   patch "/shelters/:id/reviews/:review_id", to: "reviews#update"
   delete "/shelters/:id/reviews/:review_id", to: "reviews#destroy"
+
+  patch "/favorites/:pet_id", to: "favorites#update"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,4 +29,5 @@ Rails.application.routes.draw do
   patch "/favorites/:pet_id", to: "favorites#update"
   delete "/favorites/:pet_id", to: "favorites#destroy"
   get "/favorites", to: "favorites#index"
+  delete "/favorites", to: "favorites#delete_all"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,5 @@ Rails.application.routes.draw do
   delete "/shelters/:id/reviews/:review_id", to: "reviews#destroy"
 
   patch "/favorites/:pet_id", to: "favorites#update"
+  get "/favorites", to: "favorites#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,6 @@ Rails.application.routes.draw do
   delete "/shelters/:id/reviews/:review_id", to: "reviews#destroy"
 
   patch "/favorites/:pet_id", to: "favorites#update"
+  delete "/favorites/:pet_id", to: "favorites#destroy"
   get "/favorites", to: "favorites#index"
 end

--- a/spec/features/favorites/add_pet_spec.rb
+++ b/spec/features/favorites/add_pet_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Pet favorites spec" do
     end
   end
 
-  describe "When I visit a pet's show page"
+  describe "When I visit a pet's show page" do
     it "I can favorite a pet" do
       visit "/pets/#{@doggo.id}"
 
@@ -42,5 +42,5 @@ RSpec.describe "Pet favorites spec" do
         expect(page).to have_content("Favorites: 1")
       end
     end
-
+  end
 end

--- a/spec/features/favorites/add_pet_spec.rb
+++ b/spec/features/favorites/add_pet_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe "Pet favorites spec" do
+  before :each do
+    @placeholder_image = "generic-image-placeholder.png"
+    @image_name = @placeholder_image[0...-4]
+
+    @shelter1 = Shelter.create(name: "Doggo House", address: "1323 Paper St", city: "Denver", state: "CO", zip: "000000")
+    @doggo = Pet.create(
+      image: @placeholder_image,
+      name: "Doggo",
+      approximate_age: 3,
+      sex: "M",
+      shelter: @shelter1,
+      description: "What a cute animal!",
+      status: "Adoptable"
+    )
+  end
+
+  it "Has favorite indicator in my navigation bar" do
+    visit "/"
+     within(".navbar") do
+       expect(page).to have_content("Favorites: 0")
+    end
+  end
+
+  describe "When I visit a pet's show page"
+    it "I can favorite a pet" do
+      visit "/pets/#{@doggo.id}"
+
+      within(".navbar") do
+        expect(page).to have_content("Favorites: 0")
+      end
+
+      click_button "Add Pet to Favorites"
+
+      expect(current_path).to eq("/pets/#{@doggo.id}")
+
+      expect(page).to have_content("You have added #{@doggo.name} to your favorites.")
+
+      within(".navbar") do
+        expect(page).to have_content("Favorites: 1")
+      end
+    end
+
+end

--- a/spec/features/favorites/delete_spec.rb
+++ b/spec/features/favorites/delete_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe "Pet favorites deletion spec" do
         expect(page).to_not have_link(@doggo.name)
         expect(page).to have_content("Favorites: 0")
       end
+
+      it "I can remove all pets from my favorites" do
+        visit @dog_show_page
+        click_button "Add Pet to Favorites"
+        expect(page).to have_content("Favorites: 1")
+
+        visit "/favorites"
+        expect(page).to have_link("Remove All Pets from Favorites")
+
+        click_link "Remove All Pets from Favorites"
+        expect(current_path).to eq("/favorites")
+
+        expect(page).to have_content("You have no favorited pets")
+        expect(page).to have_content("Favorites: 0")
+      end
     end
   end
 end

--- a/spec/features/favorites/delete_spec.rb
+++ b/spec/features/favorites/delete_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Pet favorites deletion spec" do
   end
 
   describe "As a visitor after I've favorited a pet" do
-
     describe "When I visit that pet's show page " do
       it "I no longer see a link to favorite that pet" do
         visit @dog_show_page
@@ -35,9 +34,7 @@ RSpec.describe "Pet favorites deletion spec" do
         expect(page).not_to have_button("Add Pet to Favorites")
         expect(page).to have_button("Remove Pet from Favorites")
       end
-    end
 
-    describe "When I visit the favorites index page" do
       it "I can delete a pet from my favorites" do
         visit @dog_show_page
         expect(page).to have_content("Favorites: 0")
@@ -54,6 +51,23 @@ RSpec.describe "Pet favorites deletion spec" do
 
         expect(page).to have_button("Add Pet to Favorites")
         expect(page).not_to have_button("Remove Pet from Favorites")
+      end
+    end
+
+    describe "When I visit my favorites page" do
+      it "I can remove a pet from my favorites" do
+        visit @dog_show_page
+        click_button "Add Pet to Favorites"
+        expect(page).to have_content("Favorites: 1")
+
+        visit "/favorites"
+        expect(page).to have_button("Remove Pet from Favorites")
+
+        click_button "Remove Pet from Favorites"
+        expect(current_path).to eq("/favorites")
+
+        expect(page).to_not have_link(@doggo.name)
+        expect(page).to have_content("Favorites: 0")
       end
     end
   end

--- a/spec/features/favorites/delete_spec.rb
+++ b/spec/features/favorites/delete_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe "Pet favorites deletion spec" do
+  before :each do
+    @placeholder_image = "generic-image-placeholder.png"
+
+    @shelter1 = Shelter.create(name: "Doggo House",
+                               address: "1323 Paper St",
+                               city: "Denver",
+                               state: "CO",
+                               zip: "000000")
+
+    @doggo = Pet.create(image: @placeholder_image,
+                        name: "Doggo",
+                        approximate_age: 3,
+                        sex: "M",
+                        shelter: @shelter1,
+                        description: "What a cute animal!",
+                        status: "Adoptable")
+
+    @dog_show_page = "/pets/#{@doggo.id}"
+  end
+
+  describe "As a visitor after I've favorited a pet" do
+
+    describe "When I visit that pet's show page " do
+      it "I no longer see a link to favorite that pet" do
+        visit @dog_show_page
+        expect(page).to have_content("Favorites: 0")
+        expect(page).to have_button("Add Pet to Favorites")
+
+        click_button "Add Pet to Favorites"
+        expect(page).to have_content("Favorites: 1")
+
+        expect(page).not_to have_button("Add Pet to Favorites")
+        expect(page).to have_button("Remove Pet from Favorites")
+      end
+    end
+
+    describe "When I visit the favorites index page" do
+      it "I can delete a pet from my favorites" do
+        visit @dog_show_page
+        expect(page).to have_content("Favorites: 0")
+
+        click_button "Add Pet to Favorites"
+        expect(current_path).to eq(@dog_show_page)
+        expect(page).to have_content("Favorites: 1")
+
+        click_button "Remove Pet from Favorites"
+        expect(current_path).to eq(@dog_show_page)
+
+        expect(page).to have_content("#{@doggo.name} has been removed from your favorites")
+        expect(page).to have_content("Favorites: 0")
+
+        expect(page).to have_button("Add Pet to Favorites")
+        expect(page).not_to have_button("Remove Pet from Favorites")
+      end
+    end
+  end
+end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -69,4 +69,12 @@ RSpec.describe "Pet favorites spec" do
       expect(current_path).to eq("/favorites")
     end
   end
+
+  describe "When I have not added any pets to my favorites list" do
+    it "I see text saying that I have no favorited pets" do
+      visit "/favorites"
+
+      expect(page).to have_content("You have no favorited pets")
+    end
+  end
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe "Pet favorites spec" do
+  before :each do
+    @placeholder_image = "generic-image-placeholder.png"
+    @image_name = @placeholder_image[0...-4]
+
+    @shelter1 = Shelter.create(name: "Doggo House", address: "1323 Paper St", city: "Denver", state: "CO", zip: "000000")
+    @doggo = Pet.create(
+      image: @placeholder_image,
+      name: "Doggo",
+      approximate_age: 3,
+      sex: "M",
+      shelter: @shelter1,
+      description: "What a cute animal!",
+      status: "Adoptable"
+    )
+
+    @catto = Pet.create(
+      image: @placeholder_image,
+      name: "Catto",
+      approximate_age: 7,
+      sex: "F",
+      shelter: @shelter1,
+      description: "What a cute animal!",
+      status: "Adoptable"
+    )
+  end
+
+  describe "When I have added pets to my favorites list" do
+    it "I see all pets I've favorited and their information" do
+
+      visit "/pets/#{@doggo.id}"
+
+      click_button "Add Pet to Favorites"
+
+      visit "/pets/#{@catto.id}"
+
+      click_button "Add Pet to Favorites"
+
+      visit "/favorites"
+
+      expect(page).to have_content(@doggo.name)
+      expect(page).to have_link(@doggo.name, href: "/pets/#{@doggo.id}")
+
+      doggo_image = find("#doggo-image")
+      expect(doggo_image[:src]).to include(@image_name)
+      expect(doggo_image[:alt]).to eq("#{@doggo.name}'s photo.")
+
+
+      expect(page).to have_content(@catto.name)
+      expect(page).to have_link(@catto.name, href: "/pets/#{@catto.id}")
+
+      catto_image = find("#catto-image")
+      expect(catto_image[:src]).to include(@image_name)
+      expect(catto_image[:alt]).to eq("#{@catto.name}'s photo.")
+    end
+  end
+
+  describe "When I click on the favorite indicator in the nav bar" do
+    it "I am taken to the favorites index page" do
+      visit "/"
+
+      within(".navbar") do
+        expect(page).to have_link("Favorites:", href: "/favorites")
+        click_link "Favorites:"
+      end
+
+      expect(current_path).to eq("/favorites")
+    end
+  end
+end

--- a/spec/models/favorites_spec.rb
+++ b/spec/models/favorites_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Favorites do
+
+  describe "#total_count" do
+    it "can count all of the pets" do
+      favorites = Favorites.new({
+        '1' => 3,
+        '2' => 3
+      })
+      expect(favorites.total_count).to eq(6)
+    end
+  end
+
+  describe "#add_pet(id)" do
+    it "can add pet" do
+      favorites = Favorites.new({
+        '1' => 3,
+        '2' => 3
+      })
+      favorites.add_pet(2)
+      expect(favorites.total_count).to eq(7)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds completed functionality for User Stories 8-15.

- A visitor can add a pet to / remove a pet from their favorites from the pet's show page
- They will see a flash message to tell them it was added or removed
- Pets cannot be favorited more than once
- Favorited pets can be seen from the Favorites index page
- The nav bar can has a Favorites indicator that links to the Favorites index page
- If a visitor has not favorited any pets, the Favorites index page will say so
- A visitor can remove pets from their  Favorites index page one-by-one or all-at-once.